### PR TITLE
feat: Create tasmota device interface and http implementation

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,24 @@
+name: Gosec
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -9,15 +9,10 @@ on:
       - '**'
 
 jobs:
-
-  tests:
+  Gosec:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,17 @@
+name: Linter
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  Golint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v3
+      - name: Run Golint
+        uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Testing
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Go workspace file
 go.work
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kevinpita/tasmotamanager
+
+go 1.21.0

--- a/tasmotamanager.go
+++ b/tasmotamanager.go
@@ -1,0 +1,5 @@
+package tasmotamanager
+
+type TasmotaDevice interface {
+	SendCommand(string) error
+}

--- a/tasmotawebdevice.go
+++ b/tasmotawebdevice.go
@@ -35,9 +35,7 @@ func NewWebDevice(deviceUrl string, username string, password string) (*TasmotaW
 }
 
 func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {
-	q := t.Url.Query()
-	q.Set("cmnd", c)
-	t.Url.RawQuery = q.Encode()
+	t.command(c)
 
 	resp, errReq := http.Get(t.Url.String())
 	if errReq != nil {
@@ -57,4 +55,10 @@ func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {
 	}
 
 	return result, nil
+}
+
+func (t *TasmotaWebDevice) command(c string) {
+	q := t.Url.Query()
+	q.Set("cmnd", c)
+	t.Url.RawQuery = q.Encode()
 }

--- a/tasmotawebdevice.go
+++ b/tasmotawebdevice.go
@@ -1,0 +1,48 @@
+package tasmotamanager
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type TasmotaWebDevice struct {
+	Url string
+}
+
+func NewWebDevice(deviceUrl string, username string, password string) *TasmotaWebDevice {
+	var baseUrl string
+	if strings.HasSuffix(deviceUrl, "/") {
+		baseUrl = fmt.Sprintf("%scm?", deviceUrl)
+	} else {
+		baseUrl = fmt.Sprintf("%s/cm?", deviceUrl)
+	}
+
+	if len(username) != 0 && len(password) != 0 {
+		auth := fmt.Sprintf("user=%s&password=%s", username, password)
+		baseUrl = fmt.Sprintf("%s%s&", baseUrl, url.QueryEscape(auth))
+	}
+
+	return &TasmotaWebDevice{baseUrl}
+}
+
+func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {
+	urlRequest := fmt.Sprintf("%scmnd=%s", t.Url, url.QueryEscape(c))
+	resp, err := http.Get(urlRequest)
+	if err != nil {
+		return nil, fmt.Errorf("sendcommand get: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+
+	var result map[string]string
+	errJson := json.Unmarshal(body, &result)
+	if errJson != nil {
+		return nil, fmt.Errorf("sendcommand unmarshal: %w", errJson)
+	}
+
+	return result, nil
+}

--- a/tasmotawebdevice.go
+++ b/tasmotawebdevice.go
@@ -35,7 +35,7 @@ func NewWebDevice(deviceUrl string, username string, password string) (*TasmotaW
 }
 
 func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {
-	t.command(c)
+	t.prepareCommandUrl(c)
 
 	resp, errReq := http.Get(t.Url.String())
 	if errReq != nil {
@@ -57,7 +57,7 @@ func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {
 	return result, nil
 }
 
-func (t *TasmotaWebDevice) command(c string) {
+func (t *TasmotaWebDevice) prepareCommandUrl(c string) {
 	q := t.Url.Query()
 	q.Set("cmnd", c)
 	t.Url.RawQuery = q.Encode()

--- a/tasmotawebdevice.go
+++ b/tasmotawebdevice.go
@@ -14,25 +14,24 @@ type TasmotaWebDevice struct {
 }
 
 func NewWebDevice(deviceUrl string, username string, password string) (*TasmotaWebDevice, error) {
-	url, errParse := url.Parse(deviceUrl)
+	u, errParse := url.Parse(deviceUrl)
 	if errParse != nil {
 		return nil, fmt.Errorf("newwebdevice parse: %w", errParse)
+	}
 
-	}
 	if !strings.HasSuffix(deviceUrl, "/") {
-		url.Path += "/"
+		u.Path += "/"
 	}
-	url.Path += "cm"
+	u.Path += "cm"
 
 	if len(username) != 0 && len(password) != 0 {
-		q := url.Query()
+		q := u.Query()
 		q.Set("user", username)
 		q.Set("password", password)
-		url.RawQuery = q.Encode()
-
+		u.RawQuery = q.Encode()
 	}
 
-	return &TasmotaWebDevice{url}, nil
+	return &TasmotaWebDevice{u}, nil
 }
 
 func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {

--- a/tasmotawebdevice.go
+++ b/tasmotawebdevice.go
@@ -31,12 +31,16 @@ func NewWebDevice(deviceUrl string, username string, password string) *TasmotaWe
 
 func (t *TasmotaWebDevice) SendCommand(c string) (map[string]string, error) {
 	urlRequest := fmt.Sprintf("%scmnd=%s", t.Url, url.QueryEscape(c))
-	resp, err := http.Get(urlRequest)
-	if err != nil {
-		return nil, fmt.Errorf("sendcommand get: %w", err)
+	resp, errReq := http.Get(urlRequest)
+	if errReq != nil {
+		return nil, fmt.Errorf("sendcommand get: %w", errReq)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+
+	body, errRead := io.ReadAll(resp.Body)
+	if errRead != nil {
+		return nil, fmt.Errorf("sendcommand readall: %w", errRead)
+	}
 
 	var result map[string]string
 	errJson := json.Unmarshal(body, &result)

--- a/tasmotawebdevice_test.go
+++ b/tasmotawebdevice_test.go
@@ -2,6 +2,8 @@ package tasmotamanager
 
 import "testing"
 
+// TODO: Tests should have a mock server that could give a json response so it can be compared too
+
 func TestNoLoginDeviceBackslash(t *testing.T) {
 	const expected = "http://192.168.1.2/cm?cmnd=Power+off"
 	device, errDevice := NewWebDevice("http://192.168.1.2/", "", "")

--- a/tasmotawebdevice_test.go
+++ b/tasmotawebdevice_test.go
@@ -11,7 +11,7 @@ func TestNoLoginDeviceBackslash(t *testing.T) {
 		t.Errorf("no error was expected when creating the device -> %v", errDevice)
 	}
 
-	device.command("Power off")
+	device.prepareCommandUrl("Power off")
 	actual := device.Url.String()
 
 	if actual != expected {
@@ -26,22 +26,7 @@ func TestNoLoginDeviceNoBackslash(t *testing.T) {
 		t.Errorf("no error was expected when creating the device -> %v", errDevice)
 	}
 
-	device.command("Power off")
-	actual := device.Url.String()
-
-	if actual != expected {
-		t.Errorf("got %s expected %s", actual, expected)
-	}
-}
-
-func TestLoginDeviceNoBackslash(t *testing.T) {
-	const expected = "http://192.168.1.2/cm?cmnd=Power+off&password=pass&user=admin"
-	device, errDevice := NewWebDevice("http://192.168.1.2", "admin", "pass")
-	if errDevice != nil {
-		t.Errorf("no error was expected when creating the device -> %v", errDevice)
-	}
-
-	device.command("Power off")
+	device.prepareCommandUrl("Power off")
 	actual := device.Url.String()
 
 	if actual != expected {
@@ -56,7 +41,22 @@ func TestLoginDeviceBackslash(t *testing.T) {
 		t.Errorf("no error was expected when creating the device -> %v", errDevice)
 	}
 
-	device.command("Power off")
+	device.prepareCommandUrl("Power off")
+	actual := device.Url.String()
+
+	if actual != expected {
+		t.Errorf("got %s expected %s", actual, expected)
+	}
+}
+
+func TestLoginDeviceNoBackslash(t *testing.T) {
+	const expected = "http://192.168.1.2/cm?cmnd=Power+off&password=pass&user=admin"
+	device, errDevice := NewWebDevice("http://192.168.1.2", "admin", "pass")
+	if errDevice != nil {
+		t.Errorf("no error was expected when creating the device -> %v", errDevice)
+	}
+
+	device.prepareCommandUrl("Power off")
 	actual := device.Url.String()
 
 	if actual != expected {

--- a/tasmotawebdevice_test.go
+++ b/tasmotawebdevice_test.go
@@ -1,0 +1,63 @@
+package tasmotamanager
+
+import "testing"
+
+func TestNoLoginDeviceBackslash(t *testing.T) {
+	const expected = "http://192.168.1.2/cm?cmnd=Power+off"
+	device, errDevice := NewWebDevice("http://192.168.1.2/", "", "")
+	if errDevice != nil {
+		t.Errorf("no error was expected when creating the device -> %v", errDevice)
+	}
+
+	device.command("Power off")
+	actual := device.Url.String()
+
+	if actual != expected {
+		t.Errorf("got %s expected %s", actual, expected)
+	}
+}
+
+func TestNoLoginDeviceNoBackslash(t *testing.T) {
+	const expected = "http://192.168.1.2/cm?cmnd=Power+off"
+	device, errDevice := NewWebDevice("http://192.168.1.2", "", "")
+	if errDevice != nil {
+		t.Errorf("no error was expected when creating the device -> %v", errDevice)
+	}
+
+	device.command("Power off")
+	actual := device.Url.String()
+
+	if actual != expected {
+		t.Errorf("got %s expected %s", actual, expected)
+	}
+}
+
+func TestLoginDeviceNoBackslash(t *testing.T) {
+	const expected = "http://192.168.1.2/cm?cmnd=Power+off&password=pass&user=admin"
+	device, errDevice := NewWebDevice("http://192.168.1.2", "admin", "pass")
+	if errDevice != nil {
+		t.Errorf("no error was expected when creating the device -> %v", errDevice)
+	}
+
+	device.command("Power off")
+	actual := device.Url.String()
+
+	if actual != expected {
+		t.Errorf("got %s expected %s", actual, expected)
+	}
+}
+
+func TestLoginDeviceBackslash(t *testing.T) {
+	const expected = "http://192.168.1.2/cm?cmnd=Power+off&password=pass&user=admin"
+	device, errDevice := NewWebDevice("http://192.168.1.2/", "admin", "pass")
+	if errDevice != nil {
+		t.Errorf("no error was expected when creating the device -> %v", errDevice)
+	}
+
+	device.command("Power off")
+	actual := device.Url.String()
+
+	if actual != expected {
+		t.Errorf("got %s expected %s", actual, expected)
+	}
+}


### PR DESCRIPTION
This PR introduces an interface for Tasmota communication methods. Currently, it supports HTTP, but it's designed to support future methods like MQTT.